### PR TITLE
Fix forceAux in perfect-tense and past-participle

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,6 +342,8 @@ function conjugate(cVerb, cMode, cTense, fGender = false, forceAux = null) {
 					verb = verb[0];
 				else
 					verb = forceAux;
+			} else if (forceAux) {
+				verb = forceAux;
 			}
 		}
 		tense = composedTenses[cTense].tense;
@@ -389,6 +391,8 @@ function conjugate(cVerb, cMode, cTense, fGender = false, forceAux = null) {
 							pVerb = pVerb[0];
 						else
 							pVerb = forceAux;
+					} else if (forceAux) {
+						pVerb = forceAux;
 					}
 				}
 				const participleAnt = conjugation[verbs[pVerb].t]["participle"]["present-participle"].i;
@@ -420,6 +424,8 @@ function conjugate(cVerb, cMode, cTense, fGender = false, forceAux = null) {
 						pVerb = pVerb[0];
 					else
 						pVerb = forceAux;
+				} else if (forceAux) {
+					pVerb = forceAux;
 				}
 			}
 			const participleAnt = conjugation[verbs[pVerb].t]["participle"]["present-participle"].i;


### PR DESCRIPTION
Allow to force aux in `perfect-tense` and `past-participle`. Like in:
 _« La souris est mangée par le chat »
 « La chatte a mangé la souris »_

```js
const conjugationFR = require("./index");

console.log(conjugationFR.conjugate("manger", "indicative", "perfect-tense", true)[2]);
console.log(conjugationFR.conjugate("manger", "indicative", "perfect-tense", true, "être")[2]);

console.log(conjugationFR.conjugate("manger", "participle", "past-participle", true));
console.log(conjugationFR.conjugate("manger", "participle", "past-participle", true, "être"));
```

Before:

```js
{ pronoun: 'elle', pronounIndex: 2, verb: 'a mangé' }
{ pronoun: 'elle', pronounIndex: 2, verb: 'a mangé' }
[
  { pronoun: 'i', pronounIndex: -1, verb: 'mangée' },
  { pronoun: 'i', pronounIndex: -1, verb: 'ayant mangée' }
]
[
  { pronoun: 'i', pronounIndex: -1, verb: 'mangée' },
  { pronoun: 'i', pronounIndex: -1, verb: 'ayant mangée' }
]
```

After:
```js
{ pronoun: 'elle', pronounIndex: 2, verb: 'a mangé' }
{ pronoun: 'elle', pronounIndex: 2, verb: 'est mangée' }
[
  { pronoun: 'i', pronounIndex: -1, verb: 'mangée' },
  { pronoun: 'i', pronounIndex: -1, verb: 'ayant mangée' }
]
[
  { pronoun: 'i', pronounIndex: -1, verb: 'mangée' },
  { pronoun: 'i', pronounIndex: -1, verb: 'étant mangée' }
]
```